### PR TITLE
Added a "dylib" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ regex = "1"
 [features]
 default = ["macros"]
 macros = []
+dylib = []

--- a/build/bind.rs
+++ b/build/bind.rs
@@ -68,7 +68,12 @@ pub fn link_libs() {
     }
 
     // Link raylib itself
-    println!("cargo:rustc-link-lib=static=raylib");
+    if cfg!(feature = "dylib") {
+        println!("cargo:rustc-link-lib=dylib=raylib");
+    }
+    else {
+        println!("cargo:rustc-link-lib=static=raylib");
+    }
 }
 
 /// Generates `bindings.rs` file


### PR DESCRIPTION
It enables linking with raylib dynamically instead of statically.

Linking raylib dynamically allows you to hot reload game logic that uses it while keeping raylibs global state in tact.

I'm still learning about feature flags and pull requests on git, so I hope I did everything correctly.