### PR TITLE
when linking dynamically raylib should BUILD_SHARED_LIBS

### DIFF
--- a/build/bind.rs
+++ b/build/bind.rs
@@ -10,6 +10,10 @@ pub fn compile_raylib(raylib_path: &str) {
         .define("BUILD_EXAMPLES", "OFF")
         .define("CMAKE_BUILD_TYPE", "Release");
 
+    if cfg!(feature = "dylib") {
+        cmake_config.define("BUILD_SHARED_LIBS", "ON");
+    }
+
     // Set the correct build profile
     #[cfg(debug_assertions)]
     {


### PR DESCRIPTION
now dynamic linking should work.
Sorry for the extra work, if I had tested more thoroughly, this could have been in the last pull request.